### PR TITLE
Update JSONMessage for 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,29 +144,47 @@ If you want to see all the available methods, you can find them just below this.
 
 ## Methods overview
 
-Method | Description
------- | -----------
-`create(String)` | Creates a new JSONMessage with the given text as a starting point
+### Text/Styling
+Method             | Description
+------------------ | -----------
+`bar()`            | Creates a horizontal divider bar 53 characters long. This is perfect for the default chat window width
+`bar(int)`         | Creates a horizontal divider bar of the given length
+`create(String)`   | Creates a new JSONMessage with the given text as a starting point
 `color(ChatColor)` | Sets the color of the current message part
+`newline()`        | Inserts a newline. It really isn't necessary, you can just use `\n` if you want
 `style(ChatColor)` | Adds a style to the current message part
-`runCommand(String)` | `ClickEvent`: Runs the given command
-`suggestCommand(String)` |  `ClickEvent`: Suggests the given command by inserting it into the player's chat area
-`openURL(String)` | `ClickEvent`: Opens the given URL
-`changePage(int)` | `ClickEvent`: changes the page of a book to the given page
-`tooltip(String)` | `HoverEvent`: shows the given text
-`tooltip(JSONMessage)` | `HoverEvent`: shows the given JSON as text (works just like the rest of this system)
-`achievement(String)` | `HoverEvent`: shows an achievement with the given ID
-`then(String)` | Adds another part to the message
-`bar(int)` | Creates a horizontal divider bar of the given length
-`bar()` | Creates a horizontal divider bar 53 characters long. This is perfect for the default chat window width
-`newline()` | Inserts a newline. It really isn't necessary, you can just use `\n` if you want
-`toJSON()` | Converts the JSONMessage to a `JsonObject` (Google's Gson library, comes with Bukkit)
+`then(String)`     | Adds another part to the message
+
+### HoverAction
+Method                 | Description
+---------------------- | -----------
+`achievement(String)`  | Shows an achievement with the given ID
+`tooltip(JSONMessage)` | Shows the given JSON as text (works just like the rest of this system)
+`tooltip(String)`      | Shows the given text
+
+### ClickAction
+Method                   | Description
+------------------------ | -----------
+`changePage(int)`        | Changes the page of a book to the given page
+`copyText(String)`       | Copies the provided text into the Player's clipboard (1.15+ only. Will default to `suggestCommand(String)`)
+`openURL(String)`        | Opens the given URL
+`runCommand(String)`     | Runs the given command
+`suggestCommand(String)` | Suggests the given command by inserting it into the player's chat area
+
+### Sending
+Method                                  | Description
+--------------------------------------- | -----------
+`actionbar(Player...)`                  | Converts the JSONMessage to the legacy format and sends it to one or multiple players
+`(static) actionbar(String, Player...)` | Sends an action-bar message to one or multiple players
+`send(Player...)`                       | Sends the JSONMessage to one or multiple players
+`subtitle(Player...)`                   | Sends the JSONMessage as a subtitle to one or multiple players
+`title(int, int, int, Player...)`       | Sends the JSONMessage as a title to one or multiple players. Int parameters are `fadeIn`, `stay`, and `fadeOut`
+
+### Others
+Method       | Description
+------------ | -----------
+`toJSON()`   | Converts the JSONMessage to a `JsonObject` (Google's Gson library, comes with Bukkit)
 `toString()` | Converts the JSONMessage to a String, usable in things like `/tellraw`. This is an alias of `toJSON().toString()`
-`send(Player...)` | Sends the JSONMessage to one or many players
-`title(int, int, int, Player...)` | Sends the JSONMessage as a title to one or many players. Int parameters are `fadeIn`, `stay`, and `fadeOut`
-`subtitle(Player...)` | Sends the JSONMessage as a subtitle to one or many players
-`(static) actionbar(String, Player...)` | Sends an action-bar message to one or many players
-`actionbar(Player...)` | Converts the JSONMessage to the legacy format and sends it to one or many players
 
 ### Method Notes
 

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -20,10 +20,10 @@ import java.lang.reflect.Method;
 import java.util.*;
 
 /**
- *  This is a complete JSON message builder class. To create a new JSONMessage do
- *  {@link #create(String)}
- *  
- *  @author Rayzr
+ * This is a complete JSON message builder class. To create a new JSONMessage do
+ * {@link #create(String)}
+ * 
+ * @author Rayzr
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class JSONMessage {

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -30,14 +30,14 @@ import java.util.Vector;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class JSONMessage {
     private static final BiMap<ChatColor, String> stylesToNames;
-
+    
     static {
         ImmutableBiMap.Builder<ChatColor, String> builder = ImmutableBiMap.builder();
         for (final ChatColor style : ChatColor.values()) {
             if (!style.isFormat()) {
                 continue;
             }
-
+            
             String styleName;
             switch (style) {
                 case MAGIC:
@@ -50,16 +50,16 @@ public class JSONMessage {
                     styleName = style.name().toLowerCase();
                     break;
             }
-
+            
             builder.put(style, styleName);
         }
         stylesToNames = builder.build();
     }
-
-
+    
+    
     private final List<MessagePart> parts = new ArrayList<>();
     private int centeringStartIndex = -1;
-
+    
     /**
      * Creates a new {@link JSONMessage} object
      *
@@ -68,7 +68,7 @@ public class JSONMessage {
     private JSONMessage(String text) {
         parts.add(new MessagePart(text));
     }
-
+    
     /**
      * Creates a new {@link JSONMessage} object
      *
@@ -78,7 +78,7 @@ public class JSONMessage {
     public static JSONMessage create(String text) {
         return new JSONMessage(text);
     }
-
+    
     /**
      * Creates a new {@link JSONMessage} object
      *
@@ -87,7 +87,7 @@ public class JSONMessage {
     public static JSONMessage create() {
         return create("");
     }
-
+    
     /**
      * Sends an action bar message
      *
@@ -97,7 +97,7 @@ public class JSONMessage {
     public static void actionbar(String message, Player... players) {
         ReflectionHelper.sendPacket(ReflectionHelper.createActionbarPacket(ChatColor.translateAlternateColorCodes('&', message)), players);
     }
-
+    
     /**
      * @return The latest {@link MessagePart}
      * @throws ArrayIndexOutOfBoundsException If {@code parts.size() <= 0}.
@@ -108,7 +108,7 @@ public class JSONMessage {
         }
         return parts.get(parts.size() - 1);
     }
-
+    
     /**
      * Converts this {@link JSONMessage} instance to actual JSON
      *
@@ -116,20 +116,20 @@ public class JSONMessage {
      */
     public JsonObject toJSON() {
         JsonObject obj = new JsonObject();
-
+        
         obj.addProperty("text", "");
-
+        
         JsonArray array = new JsonArray();
-
+        
         parts.stream()
                 .map(MessagePart::toJSON)
                 .forEach(array::add);
-
+        
         obj.add("extra", array);
-
+        
         return obj;
     }
-
+    
     /**
      * Converts this {@link JSONMessage} object to a String representation of the JSON.
      * This is an alias of {@code toJSON().toString()}.
@@ -138,7 +138,7 @@ public class JSONMessage {
     public String toString() {
         return toJSON().toString();
     }
-
+    
     /**
      * Converts this {@link JSONMessage} object to the legacy formatting system, which
      * uses formatting codes (like &amp;6, &amp;l, &amp;4, etc.)
@@ -147,23 +147,28 @@ public class JSONMessage {
      */
     public String toLegacy() {
         StringBuilder output = new StringBuilder();
-
+        
         parts.stream()
                 .map(MessagePart::toLegacy)
                 .forEach(output::append);
-
+        
         return output.toString();
     }
-
+    
     /**
      * Sends this {@link JSONMessage} to all the players specified
      *
      * @param players The players you want to send this to
      */
     public void send(Player... players) {
+        if (ReflectionHelper.MAJOR_VER >= 16) {
+            ReflectionHelper.sendTextPacket(toString(), players);
+            return;
+        }
+        
         ReflectionHelper.sendPacket(ReflectionHelper.createTextPacket(toString()), players);
     }
-
+    
     /**
      * Sends this as a title to all the players specified
      *
@@ -176,7 +181,7 @@ public class JSONMessage {
         ReflectionHelper.sendPacket(ReflectionHelper.createTitleTimesPacket(fadeIn, stay, fadeOut), players);
         ReflectionHelper.sendPacket(ReflectionHelper.createTitlePacket(toString()), players);
     }
-
+    
     /**
      * Sends this as a subtitle to all the players specified. Must be used after sending a {@link #title(int, int, int, Player...) title}.
      *
@@ -185,7 +190,7 @@ public class JSONMessage {
     public void subtitle(Player... players) {
         ReflectionHelper.sendPacket(ReflectionHelper.createSubtitlePacket(toString()), players);
     }
-
+    
     /**
      * Sends an action bar message
      *
@@ -194,7 +199,7 @@ public class JSONMessage {
     public void actionbar(Player... players) {
         actionbar(toLegacy(), players);
     }
-
+    
     /**
      * Sets the color of the current message part.
      *
@@ -205,7 +210,7 @@ public class JSONMessage {
         last().setColor(color);
         return this;
     }
-
+    
     /**
      * Adds a style to the current message part.
      *
@@ -216,7 +221,7 @@ public class JSONMessage {
         last().addStyle(style);
         return this;
     }
-
+    
     /**
      * Makes the text run a command.
      *
@@ -227,7 +232,7 @@ public class JSONMessage {
         last().setOnClick(ClickEvent.runCommand(command));
         return this;
     }
-
+    
     /**
      * Makes the text suggest a command.
      *
@@ -238,7 +243,7 @@ public class JSONMessage {
         last().setOnClick(ClickEvent.suggestCommand(command));
         return this;
     }
-
+    
     /**
      * Opens a URL.
      *
@@ -249,7 +254,19 @@ public class JSONMessage {
         last().setOnClick(ClickEvent.openURL(url));
         return this;
     }
-
+    
+    /**
+     * Copies the provided text to the Clipboard of the player.
+     * <br>This can only be used in 1.15 or newer and defaults to {@link ClickEvent#suggestCommand(String) Suggesting the text}.
+     * 
+     * @param text The text to copy
+     * @return This {@link JSONMessage} instance
+     */
+    public JSONMessage copyText(String text) {
+        last().setOnClick(ClickEvent.copyText(text));
+        return this;
+    }
+    
     /**
      * Changes the page of a book. Using this in a non-book context is useless
      * and will probably error.
@@ -261,7 +278,7 @@ public class JSONMessage {
         last().setOnClick(ClickEvent.changePage(page));
         return this;
     }
-
+    
     /**
      * Shows text when you hover over it
      *
@@ -272,7 +289,7 @@ public class JSONMessage {
         last().setOnHover(HoverEvent.showText(text));
         return this;
     }
-
+    
     /**
      * Shows text when you hover over it
      *
@@ -283,7 +300,7 @@ public class JSONMessage {
         last().setOnHover(HoverEvent.showText(message));
         return this;
     }
-
+    
     /**
      * Shows an achievement when you hover over it
      *
@@ -294,7 +311,7 @@ public class JSONMessage {
         last().setOnHover(HoverEvent.showAchievement(id));
         return this;
     }
-
+    
     /**
      * Adds another part to this {@link JSONMessage}
      *
@@ -304,7 +321,7 @@ public class JSONMessage {
     public JSONMessage then(String text) {
         return then(new MessagePart(text));
     }
-
+    
     /**
      * Adds another part to this {@link JSONMessage}
      *
@@ -315,7 +332,7 @@ public class JSONMessage {
         parts.add(nextPart);
         return this;
     }
-
+    
     /**
      * Adds a horizontal bar to the message of the given length
      *
@@ -325,7 +342,7 @@ public class JSONMessage {
     public JSONMessage bar(int length) {
         return then(Strings.repeat("-", length)).color(ChatColor.DARK_GRAY).style(ChatColor.STRIKETHROUGH);
     }
-
+    
     /**
      * Adds a horizontal bar to the message that's 53 characters long. This is
      * the default width of the player's chat window.
@@ -335,7 +352,7 @@ public class JSONMessage {
     public JSONMessage bar() {
         return bar(53);
     }
-
+    
     /**
      * Adds a blank line to the message
      *
@@ -344,7 +361,7 @@ public class JSONMessage {
     public JSONMessage newline() {
         return then("\n");
     }
-
+    
     /**
      * Sets the starting point to begin centering JSONMessages.
      *
@@ -355,7 +372,7 @@ public class JSONMessage {
         centeringStartIndex = parts.size();
         return this;
     }
-
+    
     /**
      * Ends the centering of the JSONMessage text.
      *
@@ -363,15 +380,15 @@ public class JSONMessage {
      */
     public JSONMessage endCenter() {
         int current = centeringStartIndex;
-
+        
         while (current < parts.size()) {
             Vector<MessagePart> currentLine = new Vector<>();
             int totalLineLength = 0;
-
+            
             for (; ; current++) {
                 MessagePart part = current < parts.size() ? parts.get(current) : null;
                 String raw = part == null ? null : ChatColor.stripColor(part.toLegacy());
-
+                
                 if (current >= parts.size() || totalLineLength + raw.length() >= 53) {
                     int padding = Math.max(0, (53 - totalLineLength) / 2);
                     currentLine.firstElement().setText(Strings.repeat(" ", padding) + currentLine.firstElement().getText());
@@ -379,24 +396,24 @@ public class JSONMessage {
                     currentLine.clear();
                     break;
                 }
-
+                
                 totalLineLength += raw.length();
                 currentLine.add(part);
             }
         }
-
+        
         MessagePart last = parts.get(parts.size() - 1);
         last.setText(last.getText().substring(0, last.getText().length() - 1));
-
+        
         centeringStartIndex = -1;
-
+        
         return this;
     }
-
+    
     ///////////////////////////
     // BEGIN UTILITY CLASSES //
     ///////////////////////////
-
+    
     /**
      * Represents the JSON format that all click/hover events in JSON messages must follow.
      * <br>
@@ -406,61 +423,67 @@ public class JSONMessage {
      * @author Rayzr
      */
     public static class MessageEvent {
-
+        
         private String action;
         private Object value;
-
+        
         public MessageEvent(String action, Object value) {
             this.action = action;
             this.value = value;
         }
-
+        
         /**
          * @return A {@link JsonObject} representing the properties of this {@link MessageEvent}
          */
         public JsonObject toJSON() {
             JsonObject obj = new JsonObject();
             obj.addProperty("action", action);
+            /*
+             * MC 1.16 changed "value" to "contents", but only for Hover events... Don't ask why.
+             * Since this lib only has tooltip and achievement can we simply check if action starts with "show_"
+             */
+            String valueType = (ReflectionHelper.MAJOR_VER >= 16 && action.startsWith("show_")) ? "contents" : "value";
+            
             if (value instanceof JsonElement) {
-                obj.add("value", (JsonElement) value);
+                obj.add(valueType, (JsonElement) value);
             } else {
-                obj.addProperty("value", value.toString());
+                obj.addProperty(valueType, value.toString());
             }
             return obj;
         }
-
+        
         /**
          * @return The action
          */
         public String getAction() {
             return action;
         }
-
+        
         /**
          * @param action The action to set
          */
         public void setAction(String action) {
             this.action = action;
         }
-
+        
         /**
          * @return The value
          */
         public Object getValue() {
             return value;
         }
-
+        
         /**
          * @param value The value to set
          */
         public void setValue(Object value) {
             this.value = value;
         }
-
+        
     }
-
+    
     public static class ClickEvent {
-
+        
         /**
          * Runs a command.
          *
@@ -470,9 +493,9 @@ public class JSONMessage {
         public static MessageEvent runCommand(String command) {
             return new MessageEvent("run_command", command);
         }
-
+        
         /**
-         * Suggests a command by putting inserting it in chat.
+         * Suggests a command by inserting it in chat.
          *
          * @param command The command to suggest
          * @return The {@link MessageEvent}
@@ -480,7 +503,7 @@ public class JSONMessage {
         public static MessageEvent suggestCommand(String command) {
             return new MessageEvent("suggest_command", command);
         }
-
+        
         /**
          * Requires web links to be enabled on the client.
          *
@@ -490,7 +513,7 @@ public class JSONMessage {
         public static MessageEvent openURL(String url) {
             return new MessageEvent("open_url", url);
         }
-
+        
         /**
          * Only used with written books.
          *
@@ -500,11 +523,25 @@ public class JSONMessage {
         public static MessageEvent changePage(int page) {
             return new MessageEvent("change_page", page);
         }
-
+    
+        /**
+         * Only usable in versions 1.15 and newer.
+         * <br>Will default to putting the command in the chat bar using {@link #suggestCommand(String)} suggestCommand(String)}
+         * 
+         * @param text The text to copy.
+         * @return The {@link MessageEvent}
+         */
+        public static MessageEvent copyText(String text) {
+            if(ReflectionHelper.MAJOR_VER < 15)
+                return suggestCommand(text);
+            
+            return new MessageEvent("copy_to_clipboard", text);
+        }
+        
     }
-
+    
     public static class HoverEvent {
-
+        
         /**
          * Shows text when you hover over it
          *
@@ -514,7 +551,7 @@ public class JSONMessage {
         public static MessageEvent showText(String text) {
             return new MessageEvent("show_text", text);
         }
-
+        
         /**
          * Shows text when you hover over it
          *
@@ -527,7 +564,7 @@ public class JSONMessage {
             arr.add(message.toJSON());
             return new MessageEvent("show_text", arr);
         }
-
+        
         /**
          * Shows an achievement when you hover over it
          *
@@ -537,11 +574,11 @@ public class JSONMessage {
         public static MessageEvent showAchievement(String id) {
             return new MessageEvent("show_achievement", id);
         }
-
+        
     }
-
+    
     private static class ReflectionHelper {
-
+        
         private static final String version;
         private static Class<?> craftPlayer;
         private static Constructor<?> chatComponentText;
@@ -559,59 +596,59 @@ public class JSONMessage {
         private static Object enumActionbarMessage;
         private static boolean SETUP;
         private static int MAJOR_VER = -1;
-
+        
         static {
             String[] split = Bukkit.getServer().getClass().getPackage().getName().split("\\.");
             version = split[split.length - 1];
-
+            
             try {
                 SETUP = true;
-
+                
                 MAJOR_VER = getVersion();
-
+                
                 craftPlayer = getClass("{obc}.entity.CraftPlayer");
                 Method getHandle = craftPlayer.getMethod("getHandle");
                 connection = getHandle.getReturnType().getField("playerConnection");
                 Method sendPacket = connection.getType().getMethod("sendPacket", getClass("{nms}.Packet"));
-
+                
                 chatComponentText = getClass("{nms}.ChatComponentText").getConstructor(String.class);
-
+                
                 iChatBaseComponent = getClass("{nms}.IChatBaseComponent");
-
+                
                 Method stringToChat;
-
+                
                 if (MAJOR_VER < 8) {
                     stringToChat = getClass("{nms}.ChatSerializer").getMethod("a", String.class);
                 } else {
                     stringToChat = getClass("{nms}.IChatBaseComponent$ChatSerializer").getMethod("a", String.class);
                 }
-
+                
                 GET_HANDLE = MethodHandles.lookup().unreflect(getHandle);
                 SEND_PACKET = MethodHandles.lookup().unreflect(sendPacket);
                 STRING_TO_CHAT = MethodHandles.lookup().unreflect(stringToChat);
-
+                
                 packetPlayOutChat = getClass("{nms}.PacketPlayOutChat");
                 packetPlayOutTitle = getClass("{nms}.PacketPlayOutTitle");
-
+                
                 titleAction = getClass("{nms}.PacketPlayOutTitle$EnumTitleAction");
-
+                
                 enumActionTitle = titleAction.getField("TITLE").get(null);
                 enumActionSubtitle = titleAction.getField("SUBTITLE").get(null);
-
+                
                 if (MAJOR_VER >= 12) {
                     Method getChatMessageType = getClass("{nms}.ChatMessageType").getMethod("a", byte.class);
-
+                    
                     enumChatMessage = getChatMessageType.invoke(null, (byte) 1);
                     enumActionbarMessage = getChatMessageType.invoke(null, (byte) 2);
                 }
-
+                
             } catch (Exception e) {
                 e.printStackTrace();
                 SETUP = false;
             }
-
+            
         }
-
+        
         static void sendPacket(Object packet, Player... players) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -619,7 +656,7 @@ public class JSONMessage {
             if (packet == null) {
                 return;
             }
-
+            
             for (Player player : players) {
                 try {
                     SEND_PACKET.bindTo(connection.get(GET_HANDLE.bindTo(player).invoke())).invoke(packet);
@@ -628,15 +665,15 @@ public class JSONMessage {
                     e.printStackTrace();
                 }
             }
-
+            
         }
-
+        
         private static void setType(Object object, byte type) {
             if (MAJOR_VER < 12) {
                 set("b", object, type);
                 return;
             }
-
+            
             switch (type) {
                 case 1:
                     set("b", object, enumChatMessage);
@@ -648,7 +685,7 @@ public class JSONMessage {
                     throw new IllegalArgumentException("type must be 1 or 2");
             }
         }
-
+        
         static Object createActionbarPacket(String message) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -657,7 +694,7 @@ public class JSONMessage {
             setType(packet, (byte) 2);
             return packet;
         }
-
+        
         static Object createTextPacket(String message) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -671,9 +708,25 @@ public class JSONMessage {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
+        static void sendTextPacket(String message, Player... players) {
+            try {
+                for (Player player : players) {
+                    Class chatTypeClass = getClass("{nms}.ChatMessageType");
+                    Constructor<?> constructor = packetPlayOutChat.getConstructor(getClass("{nms}.IChatBaseComponent"), chatTypeClass, UUID.class);
+                    Object packet = constructor.newInstance(fromJson(message), Enum.valueOf(chatTypeClass, "CHAT"), player.getUniqueId());
+                    
+                    Object handler = player.getClass().getMethod("getHandle").invoke(player);
+                    Object playerConnection = handler.getClass().getField("playerConnection").get(handler);
+                    playerConnection.getClass().getMethod("sendPacket", getClass("{nms}.Packet")).invoke(playerConnection, packet);
+                }
+            } catch (IllegalArgumentException | NoSuchMethodException | NoSuchFieldException | IllegalAccessException | InvocationTargetException | InstantiationException | ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
+        
         static Object createTitlePacket(String message) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -684,9 +737,9 @@ public class JSONMessage {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
         static Object createSubtitlePacket(String message) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -697,9 +750,9 @@ public class JSONMessage {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
         static Object createTitleTimesPacket(int fadeIn, int stay, int fadeOut) {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -710,9 +763,9 @@ public class JSONMessage {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
         /**
          * Creates a ChatComponentText from plain text
          *
@@ -729,9 +782,9 @@ public class JSONMessage {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
         /**
          * Attempts to convert a String representing a JSON message into a usable object
          *
@@ -745,16 +798,16 @@ public class JSONMessage {
             if (!json.trim().startsWith("{")) {
                 return componentText(json);
             }
-
+            
             try {
                 return STRING_TO_CHAT.invoke(json);
             } catch (Throwable e) {
                 e.printStackTrace();
                 return null;
             }
-
+            
         }
-
+        
         /**
          * Returns a class with the given package and name. This method replaces <code>{nms}</code> with <code>net.minecraft.server.[version]</code> and <code>{obc}</code> with <code>org.bukkit.craft.[version]</code>
          * <br>
@@ -775,7 +828,7 @@ public class JSONMessage {
             }
             return Class.forName(path.replace("{nms}", "net.minecraft.server." + version).replace("{obc}", "org.bukkit.craftbukkit." + version));
         }
-
+        
         /**
          * Sets a field with the given name on an object to the value specified
          *
@@ -792,7 +845,11 @@ public class JSONMessage {
                 e.printStackTrace();
             }
         }
-
+        
+        public static String getStringVersion() {
+            return version;
+        }
+        
         static int getVersion() {
             if (!SETUP) {
                 throw new IllegalStateException("ReflectionHelper is not set up!");
@@ -803,11 +860,11 @@ public class JSONMessage {
                 e.printStackTrace();
                 return 10;
             }
-
+            
         }
-
+        
     }
-
+    
     /**
      * Defines a section of the message, and represents the format that all JSON messages must follow in Minecraft.
      * <br>
@@ -816,18 +873,18 @@ public class JSONMessage {
      *
      * @author Rayzr
      */
-    public class MessagePart {
-
+    public static class MessagePart {
+        
         private final List<ChatColor> styles = new ArrayList<>();
         private MessageEvent onClick;
         private MessageEvent onHover;
         private ChatColor color;
         private String text;
-
+        
         public MessagePart(String text) {
             this.text = text == null ? "null" : text;
         }
-
+        
         /**
          * Converts this {@link MessagePart} into a {@link JsonObject}
          *
@@ -835,30 +892,30 @@ public class JSONMessage {
          */
         public JsonObject toJSON() {
             Objects.requireNonNull(text);
-
+            
             JsonObject obj = new JsonObject();
             obj.addProperty("text", text);
-
+            
             if (color != null) {
                 obj.addProperty("color", color.name().toLowerCase());
             }
-
+            
             for (ChatColor style : styles) {
                 obj.addProperty(stylesToNames.get(style), true);
             }
-
+            
             if (onClick != null) {
                 obj.add("clickEvent", onClick.toJSON());
             }
-
+            
             if (onHover != null) {
                 obj.add("hoverEvent", onHover.toJSON());
             }
-
+            
             return obj;
-
+            
         }
-
+        
         /**
          * @return This {@link MessagePart} in legacy-style color/formatting codes
          */
@@ -870,45 +927,45 @@ public class JSONMessage {
             styles.stream()
                     .map(ChatColor::toString)
                     .forEach(output::append);
-
+            
             return output.append(text).toString();
         }
-
+        
         /**
          * @return The click event bound
          */
         public MessageEvent getOnClick() {
             return onClick;
         }
-
+        
         /**
          * @param onClick The new click event to bind
          */
         public void setOnClick(MessageEvent onClick) {
             this.onClick = onClick;
         }
-
+        
         /**
          * @return The hover event bound
          */
         public MessageEvent getOnHover() {
             return onHover;
         }
-
+        
         /**
          * @param onHover The new hover event to bind
          */
         public void setOnHover(MessageEvent onHover) {
             this.onHover = onHover;
         }
-
+        
         /**
          * @return The color
          */
         public ChatColor getColor() {
             return color;
         }
-
+        
         /**
          * @param color The color to set
          */
@@ -918,14 +975,14 @@ public class JSONMessage {
             }
             this.color = color;
         }
-
+        
         /**
          * @return The list of styles
          */
         public List<ChatColor> getStyles() {
             return styles;
         }
-
+        
         /**
          * @param style The new style to add
          */
@@ -938,21 +995,20 @@ public class JSONMessage {
             }
             styles.add(style);
         }
-
+        
         /**
          * @return The raw text
          */
         public String getText() {
             return text;
         }
-
+        
         /**
          * @param text The raw text to set
          */
         public void setText(String text) {
             this.text = text;
         }
-
+        
     }
-
 }

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -15,20 +15,12 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Vector;
+import java.util.*;
 
-/**
- * This is a complete JSON message builder class. To create a new JSONMessage do
- * {@link #create(String)}
- *
- * @author Rayzr
- */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class JSONMessage {
+public class JSONMessage{
     private static final BiMap<ChatColor, String> stylesToNames;
     
     static {
@@ -212,6 +204,24 @@ public class JSONMessage {
     }
     
     /**
+     * Sets the color of the current message part.
+     * <br>This method allows you to provide a hex color, which can be used in 1.16 to color the message in any Hex color
+     * imaginable.
+     * 
+     * @param color The color to set
+     * @return This {@link JSONMessage} instance
+     */
+    public JSONMessage color(String color) {
+        last().setColor(color);
+        return this;
+    }
+    
+    public JSONMessage font(String font) {
+        last().setFont(font);
+        return this;
+    }
+    
+    /**
      * Adds a style to the current message part.
      *
      * @param style The style to add
@@ -258,7 +268,7 @@ public class JSONMessage {
     /**
      * Copies the provided text to the Clipboard of the player.
      * <br>This can only be used in 1.15 or newer and defaults to {@link ClickEvent#suggestCommand(String) Suggesting the text}.
-     * 
+     *
      * @param text The text to copy
      * @return This {@link JSONMessage} instance
      */
@@ -523,11 +533,11 @@ public class JSONMessage {
         public static MessageEvent changePage(int page) {
             return new MessageEvent("change_page", page);
         }
-    
+        
         /**
          * Only usable in versions 1.15 and newer.
          * <br>Will default to putting the command in the chat bar using {@link #suggestCommand(String)} suggestCommand(String)}
-         * 
+         *
          * @param text The text to copy.
          * @return The {@link MessageEvent}
          */
@@ -878,7 +888,8 @@ public class JSONMessage {
         private final List<ChatColor> styles = new ArrayList<>();
         private MessageEvent onClick;
         private MessageEvent onHover;
-        private ChatColor color;
+        private String color;
+        private String font;
         private String text;
         
         public MessagePart(String text) {
@@ -896,8 +907,8 @@ public class JSONMessage {
             JsonObject obj = new JsonObject();
             obj.addProperty("text", text);
             
-            if (color != null) {
-                obj.addProperty("color", color.name().toLowerCase());
+            if (color != null && !color.isEmpty()) {
+                obj.addProperty("color", color.toLowerCase());
             }
             
             for (ChatColor style : styles) {
@@ -912,6 +923,10 @@ public class JSONMessage {
                 obj.add("hoverEvent", onHover.toJSON());
             }
             
+            if (font != null) {
+                obj.addProperty("font", font);
+            }
+            
             return obj;
             
         }
@@ -922,7 +937,7 @@ public class JSONMessage {
         public String toLegacy() {
             StringBuilder output = new StringBuilder();
             if (color != null) {
-                output.append(color.toString());
+                output.append(color);
             }
             styles.stream()
                     .map(ChatColor::toString)
@@ -962,7 +977,7 @@ public class JSONMessage {
         /**
          * @return The color
          */
-        public ChatColor getColor() {
+        public String getColor() {
             return color;
         }
         
@@ -972,6 +987,13 @@ public class JSONMessage {
         public void setColor(ChatColor color) {
             if (!color.isColor()) {
                 throw new IllegalArgumentException(color.name() + " is not a color!");
+            }
+            setColor(color.name().toLowerCase());
+        }
+        
+        public void setColor(String color) {
+            if(color == null || color.isEmpty()){
+                throw new IllegalArgumentException("Color cannot be null!");
             }
             this.color = color;
         }
@@ -991,9 +1013,23 @@ public class JSONMessage {
                 throw new IllegalArgumentException("Style cannot be null!");
             }
             if (!style.isFormat()) {
-                throw new IllegalArgumentException(color.name() + " is not a style!");
+                throw new IllegalArgumentException(style.name() + " is not a style!");
             }
             styles.add(style);
+        }
+    
+        /**
+         * @return The font used
+         */
+        public String getFont() {
+            return font;
+        }
+    
+        /**
+         * @param font The font to use
+         */
+        public void setFont(String font) {
+            this.font = font;
         }
         
         /**
@@ -1011,4 +1047,3 @@ public class JSONMessage {
         }
         
     }
-}

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -212,6 +212,10 @@ public class JSONMessage{
      * @return This {@link JSONMessage} instance
      */
     public JSONMessage color(String color) {
+        if(color.startsWith("#") && ReflectionHelper.MAJOR_VER < 16) {
+            throw new IllegalArgumentException("Hex colors are only supported on 1.16+!");
+        }
+        
         last().setColor(color);
         return this;
     }

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -207,8 +207,7 @@ public class JSONMessage {
     public JSONMessage color(ChatColor color) {
         if (!color.isColor())
             throw new IllegalArgumentException(color.name() + " is not a color.");
-        last().setColor(color.name().toLowerCase());
-        return this;
+        return color(color.name().toLowerCase(), ChatColor.WHITE);
     }
 
     /**
@@ -1013,23 +1012,19 @@ public class JSONMessage {
 
         /**
          * @return The color
+         * 
+         * @deprecated Use {@link #getColorValue()} instead
          */
         @Deprecated
         public ChatColor getColor() {
-            if(this.color == null || this.color.isEmpty())
-                return ChatColor.WHITE;
-
             if(this.color.startsWith("#") && ReflectionHelper.MAJOR_VER < 16)
                 throw new IllegalStateException("Custom Hex colors can only be used in Minecraft 1.16 or newer!");
 
-            ChatColor color;
             try {
-                color = ChatColor.valueOf(this.color.toUpperCase());
+                return ChatColor.valueOf(this.color.toUpperCase());
             } catch (Exception ex) {
-                color = ChatColor.WHITE;
+                return null;
             }
-
-            return color;
         }
 
         /**

--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -1007,8 +1007,39 @@ public class JSONMessage {
         /**
          * @return The color
          */
-        public String getColor() {
+        public String getColorValue() {
             return color;
+        }
+
+        /**
+         * @return The color
+         */
+        @Deprecated
+        public ChatColor getColor() {
+            if(this.color == null || this.color.isEmpty())
+                return ChatColor.WHITE;
+
+            if(this.color.startsWith("#") && ReflectionHelper.MAJOR_VER < 16)
+                throw new IllegalStateException("Custom Hex colors can only be used in Minecraft 1.16 or newer!");
+
+            ChatColor color;
+            try {
+                color = ChatColor.valueOf(this.color.toUpperCase());
+            } catch (Exception ex) {
+                color = ChatColor.WHITE;
+            }
+
+            return color;
+        }
+
+        /**
+         * @param color The color to set
+         * 
+         * @deprecated Use {@link #setColor(String)} instead
+         */
+        @Deprecated
+        public void setColor(ChatColor color) {
+            setColor(color.name().toLowerCase());
         }
 
         /**


### PR DESCRIPTION
This updates JSONMessage to be compatible with 1.16 together with other small changes to make it work.

Most changes are based of the commit made by @darbyjack towards @PlaceholderAPI, so thanks to him for that.
Commit: https://github.com/PlaceholderAPI/PlaceholderAPI/commit/a70b9f8ddaf845a3bc82e0ea3d0911d566c75d58

Changes I made:
- Added `copyText(String)` method.
ClickAction that will copy the provided text to the players Clipboard. To maintain support for older versions does this default to suggestCommand when the major version is below 15.
- implemented a check to use `contents` instead of `value` when MAJOR_VER is 16 or higher and the action nam starts with `show_` (Since this only has show_text and show_achievement and only hover events seem to be affected.)
- Added support for custom hex colors using `color(String)`
- Added support for custom fonts using `font(String)`

Feel free to suggest any other changes for this PR.