### PR TITLE
Add color names as constants

### DIFF
--- a/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
+++ b/src/main/java/me/rayzr522/jsonmessage/JSONMessage.java
@@ -32,6 +32,31 @@ import java.util.Vector;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class JSONMessage {
     private static final BiMap<ChatColor, String> stylesToNames;
+    
+    // Colors
+    public static final String BLACK = "black";
+    public static final String DARK_BLUE = "dark_blue";
+    public static final String DARK_GREEN = "dark_green";
+    public static final String DARK_AQUA = "dark_aqua";
+    public static final String DARK_RED = "dark_red";
+    public static final String DARK_PURPLE = "dark_purple";
+    public static final String GOLD = "gold";
+    public static final String GRAY = "gray";
+    public static final String DARK_GRAY = "dark_gray";
+    public static final String BLUE = "blue";
+    public static final String GREEN = "green";
+    public static final String AQUA = "aqua";
+    public static final String RED = "red";
+    public static final String LIGHT_PURPLE = "light_purple";
+    public static final String YELLOW = "yellow";
+    public static final String WHITE = "white";
+    
+    // Formatting (unused yet)
+    //public static final String BOLD = "bold";
+    //public static final String ITALIC = "italic";
+    //public static final String UNDERLINE = "underline";
+    //public static final String STRIKETHROUGH = "strikethrough";
+    //public static final String OBFUSCATED = "obfuscated";
 
     static {
         ImmutableBiMap.Builder<ChatColor, String> builder = ImmutableBiMap.builder();


### PR DESCRIPTION
This adds the different color names as String constants, for easier use.

That way can devs do `JSONMessage.create("text").color(JSONMessage.AQUA)` and not worry about the right color name, if they want to use Strings (Since ChatColor method is deprecated).

I also added the names for the different Styles, but commented them out for now, as there isn't a `style(String)` method yet.